### PR TITLE
Ignore links that are already in standard markdown form.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,15 @@ const linkify = (text /*: string*/ /*: string*/) => {
     if (last < match.index) {
       result.push(text.slice(last, match.index));
     }
-    // Add the current link
-    result.push(`[${match.text}](${match.url})`);
+    // Add the current link, if it is not already an inline markdown link
+    if (
+      text.slice(match.index - 2, match.index) !== '](' &&
+      text.slice(match.lastIndex, match.lastIndex + 2) !== ']('
+    ) {
+      result.push(`[${match.text}](${match.url})`);
+    } else {
+      result.push(text.slice(match.index, match.lastIndex));
+    }
     // Set the index of this match for the next round
     last = match.lastIndex;
   });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -106,4 +106,16 @@ describe('edge cases', () => {
     const text = 'An email hi@spectrum.chat';
     expect(linkify(text)).toEqual('An email hi@spectrum.chat');
   });
+
+  it('should not change text that is already in the form of an inline markdown link', () => {
+    const text =
+      'This is [an example](http://example.com/ "Title") markdown link.';
+    expect(linkify(text)).toEqual(text);
+    const text2 =
+      'This is [an example](http://example.com/) markdown link with no Title.';
+    expect(linkify(text2)).toEqual(text2);
+    const text3 =
+      'This is [http://example.com/](http://example.com/) markdown link with matching text.';
+    expect(linkify(text3)).toEqual(text3);
+  });
 });


### PR DESCRIPTION
Not sure that this covers all edge cases, and it may not be completely robust, but here is a naive addition to ignore links that are already in markdown format.