### PR TITLE
multiple links bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,9 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
     const oldValidate = linkifier.__compiled__[schema].validate;
 
     linkifier.__compiled__[schema].validate = (text, pos, self) => {
-      const tail = text.slice(text.slice(0, pos).indexOf('['));
+      const tailIndex = text.slice(0, pos).lastIndexOf('[');
+      const tail = text.slice(tailIndex);
+      const endPrevLink = text.slice(0, pos).lastIndexOf(')');
 
       if (!self.re.markdownLink) {
         self.re.markdownLink = new RegExp(
@@ -23,7 +25,7 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
         );
       }
 
-      if (self.re.markdownLink.test(tail)) {
+      if (self.re.markdownLink.test(tail) && tailIndex > endPrevLink) {
         return false;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -15,9 +15,18 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
     const oldValidate = linkifier.__compiled__[schema].validate;
 
     linkifier.__compiled__[schema].validate = (text, pos, self) => {
-      const tailIndex = text.slice(0, pos).lastIndexOf('[');
-      const tail = text.slice(tailIndex);
-      const endPrevLink = text.slice(0, pos).lastIndexOf(')');
+      const tail = text.slice(text.slice(0, pos).lastIndexOf('['));
+
+      let startIndex;
+      let curr = pos;
+
+      // Walk backward in the string to find '(' in the markdown link
+      while (text[curr] && text[curr--] !== ' ') {
+        if (text[curr] === '(') {
+          startIndex = curr;
+          break;
+        }
+      }
 
       if (!self.re.markdownLink) {
         self.re.markdownLink = new RegExp(
@@ -25,7 +34,7 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
         );
       }
 
-      if (self.re.markdownLink.test(tail) && tailIndex > endPrevLink) {
+      if (self.re.markdownLink.test(tail) && startIndex) {
         return false;
       }
 

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -111,4 +111,20 @@ describe('edge cases', () => {
     const text = 'A link [to google](http://google.com)';
     expect(linkify(text)).toEqual(text);
   });
+
+  it('should work with multiple links', () => {
+    const text =
+      'A link [to google](http://google.com) with another link to http://google.com';
+    expect(linkify(text)).toEqual(
+      'A link [to google](http://google.com) with another link to [http://google.com](http://google.com)'
+    );
+  });
+
+  it('should work a bunch of links', () => {
+    const text =
+      'A link [to google](http://google.com) http://google.com [to google](http://google.com) http://google.com';
+    expect(linkify(text)).toEqual(
+      'A link [to google](http://google.com) [http://google.com](http://google.com) [to google](http://google.com) [http://google.com](http://google.com)'
+    );
+  });
 });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -127,4 +127,9 @@ describe('edge cases', () => {
       'A link [to google](http://google.com) [http://google.com](http://google.com) [to google](http://google.com) [http://google.com](http://google.com)'
     );
   });
+
+  it('should link text containing parens', () => {
+    const text = '[A link to (google)](http://google.com)';
+    expect(linkify(text)).toEqual('[A link to (google)](http://google.com)');
+  });
 });


### PR DESCRIPTION
Since the last PR markdown links are handled correctly. That PR did not cover the case where multiple links were in the string. The check for the first markdown link was short circuiting any transformation of subsequent links.

Now it can handle:

`A link [to google](http://google.com) with another link to http://google.com`

TODO:

still need to solve the following case 

`[A link to (google)](http://google.com)`