### PR TITLE
`[http://google.com](http://google.com)` bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,25 +15,23 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
     const oldValidate = linkifier.__compiled__[schema].validate;
 
     linkifier.__compiled__[schema].validate = (text, pos, self) => {
-      const linkStart = pos - schema.length;
-
       if (!self.re.markdownLink) {
         self.re.markdownLink = new RegExp(
           /[!&]?\[([!&]?\[.*?\)|[^\]]*?)]\((.*?)( .*?)?\)/
         );
       }
 
+      const linkStart = pos - schema.length;
       const match = text.match(self.re.markdownLink);
-      let matchLinkStart;
 
+      // Text is a markdown link
       if (match) {
-        matchLinkStart = match[1].length + 2 + match.index + 1;
-      }
+        const matchLinkStart = match[1].length + 2 + match.index + 1;
 
-      // Ensure text isn't a markdown link and that the matched link
-      // is at the current position
-      if (self.re.markdownLink.test(text) && linkStart <= matchLinkStart) {
-        return false;
+        // The matched link is at the current position
+        if (linkStart <= matchLinkStart) {
+          return false;
+        }
       }
 
       return oldValidate(text, pos, self);

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const linkify = (text /*: string*/ /*: string*/) => {
     // Set the index of this match for the next round
     last = match.lastIndex;
   });
-  // If there is text after the last match add it at the ned
+  // If there is text after the last match add it at the end
   if (last < text.length) {
     result.push(text.slice(last));
   }

--- a/src/index.js
+++ b/src/index.js
@@ -15,18 +15,7 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
     const oldValidate = linkifier.__compiled__[schema].validate;
 
     linkifier.__compiled__[schema].validate = (text, pos, self) => {
-      const tail = text.slice(text.slice(0, pos).lastIndexOf('['));
-
-      let startIndex;
-      let curr = pos;
-
-      // Walk backward in the string to find '(' in the markdown link
-      while (text[curr] && text[curr--] !== ' ') {
-        if (text[curr] === '(') {
-          startIndex = curr;
-          break;
-        }
-      }
+      const linkStart = pos - schema.length;
 
       if (!self.re.markdownLink) {
         self.re.markdownLink = new RegExp(
@@ -34,7 +23,16 @@ Object.keys(linkifier.__compiled__).forEach(schema => {
         );
       }
 
-      if (self.re.markdownLink.test(tail) && startIndex) {
+      const match = text.match(self.re.markdownLink);
+      let matchLinkStart;
+
+      if (match) {
+        matchLinkStart = match[1].length + 2 + match.index + 1;
+      }
+
+      // Ensure text isn't a markdown link and that the matched link
+      // is at the current position
+      if (self.re.markdownLink.test(text) && linkStart <= matchLinkStart) {
         return false;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,8 @@ const linkify = (text /*: string*/ /*: string*/) => {
   // No match, return the text
   if (!matches) return text;
 
+  const result = [];
   let last = 0;
-  let result = [];
   // Build up the result
   matches.forEach(match => {
     // If there is text between the last match and this one add it to the result now

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -132,4 +132,14 @@ describe('edge cases', () => {
     const text = '[A link to (google)](http://google.com)';
     expect(linkify(text)).toEqual('[A link to (google)](http://google.com)');
   });
+
+  it('should not transform markdown link with link as label', () => {
+    const text = '[http://google.com](http://google.com)';
+    expect(linkify(text)).toEqual('[http://google.com](http://google.com)');
+  });
+
+  it('should not transform markdown link with link as label', () => {
+    const text = '[ http://google.com](http://google.com)';
+    expect(linkify(text)).toEqual('[ http://google.com](http://google.com)');
+  });
 });

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -138,7 +138,7 @@ describe('edge cases', () => {
     expect(linkify(text)).toEqual('[http://google.com](http://google.com)');
   });
 
-  it('should not transform markdown link with link as label', () => {
+  it('should not transform markdown link with link as label with spaces', () => {
     const text = '[ http://google.com](http://google.com)';
     expect(linkify(text)).toEqual('[ http://google.com](http://google.com)');
   });


### PR DESCRIPTION
`markdown-linkify` was incorrectly transforming markdown links with link labels.

@mxstbr got rid of that nasty while loop I added too